### PR TITLE
Enable Rails 6.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         ruby-version: ['2.7', '3.0', '3.1']
-        rails-version: ['7.0']
+        rails-version: ['6.1', '7.0']
     runs-on: ${{ matrix.os }}
     env:
       RAILS_VERSION: "${{ matrix.rails-version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /test/boxcar/log/*.log
 /test/boxcar/tmp/
 /spec/examples.txt
-Gemfile.lock
+Gemfile.lock*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
 
 ## Unreleased
 
+### Added
+
+- Support for running Scrapbook using Rails 6.1.
+
 [Unreleased commits](https://github.com/bfad/scrapbook/compare/v0.2.1...HEAD)
 
 ## 0.2.1 (2022-08-14)

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in scrapbook.gemspec.
 gemspec
 
-gem 'propshaft'
 gem 'rails', "~> #{ENV.fetch('RAILS_VERSION', '7.0')}"
 
 # Start debugger with binding.b or debugger [https://github.com/ruby/debug]
@@ -22,3 +21,11 @@ gem 'rubocop-rails', require: false
 gem 'rubocop-rspec', require: false
 
 gem 'slim'
+
+# For the test application, boxcar, in the test folder
+if ENV.fetch('RAILS_VERSION', '7.0').to_i < 7
+  gem 'mail', '>= 2.8.0.rc1' # Remove when 2.8.0 released to support ruby 3.1
+  gem 'sprockets-rails', require: 'sprockets/railtie'
+else
+  gem 'propshaft'
+end

--- a/app/controllers/scrapbook/pages_controller.rb
+++ b/app/controllers/scrapbook/pages_controller.rb
@@ -69,6 +69,9 @@ module Scrapbook
     end
 
     def scrapbook_template_exists?(scrapbook, template)
+      # It's deprecated, but Rails 6 allows for templates to be specified with extensions.
+      return false if Rails.version.to_i == 6 && template.include?('.')
+
       EmptyController.new.tap { |c| c.prepend_view_path(scrapbook.pages_pathname) }.template_exists?(template)
     end
   end

--- a/scrapbook.gemspec
+++ b/scrapbook.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.required_ruby_version = '>= 2.7.0'
-  spec.add_dependency 'rails', '>= 7.0', '< 7.1'
+  spec.add_dependency 'rails', '>= 6.1', '< 7.1'
 end

--- a/test/boxcar/app/assets/config/manifest.js
+++ b/test/boxcar/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../stylesheets .css
+//= link scrapbook/application.css


### PR DESCRIPTION
There wasn't any reason to have the "propshaft" gem in the Gemfile since
the host application manages assets. (It was never required for the gem,
and having it in the Gemfile prevented the test suite from running for
Rails 6.) This removes that and makes slight modifications to the code
to allow Scrapbook to run appropriately in Rails 6 with Sprockets.