### PR TITLE
Change how we setup multiple scrapbooks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,12 +25,17 @@ Metrics/AbcSize:
   Max: 30
 
 Metrics/BlockLength:
-  IgnoredMethods:
-    - describe
+  AllowedMethods:
     - context
+    - describe
 
 Metrics/MethodLength:
   Max: 20
+
+RSpec:
+  Language:
+    Expectations:
+      - will_be_expected
 
 RSpec/BeNil:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
 
 - Support for running Scrapbook using Rails 6.1.
 
+### Changed
+
+- Scrapbooks are now setup / configured via the `scrapbook` routing helper instead of adding
+  the path names to the configuration file directly. This means that each scrapbook mounts
+  the Scrapbook engine for its path.
+
+- The installation generators have been updated for the new configuration architecture.
+
 [Unreleased commits](https://github.com/bfad/scrapbook/compare/v0.2.1...HEAD)
 
 ## 0.2.1 (2022-08-14)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ $> bundle install
 $> bundle exec rails generate scrapbook:install
 ```
 
-This will install the gem and setup the default Scrapbook route and create the default
-scrapbook directory structure at the root of your Rails application.
+This will install the gem and then setup a scrapbook directory structure with a folder named
+"scrapbook" at the root of your Rails application as well as modify your routes to make the
+scrapbook available.
 
 ## Usage
 
@@ -48,38 +49,32 @@ the main display area describing how to customize what is displayed when a folde
 selected. In short, you need to create a template file with the same base name as the folder
 in the same directory as the folder. So if you had a folder at "scrapbook/pages/scratch",
 then you would need to create a file named something like "scrapbook/pages/scratch.html.erb"
-with the custom display you want to see when you click on the "scratch" folder in the file
+with the custom view you want to see when you click on the "scratch" folder in the file
 browser. This also works for the main screen you see at the base scrapbook URL. You can
 customize that screen by creating a "pages.html" template file in the root scrapbook folder.
 (The default installation creates a "pages.html.erb" template file for the basic welcome
 message.)
 
-To view a scrapbook, navigate to its base URL. The default scarpbook can always be accessed
-at the mountpoint setup in the routes file (this is "/scrapbook" by default). The base URL
-for other scrapbooks is that path followed by the name of the scrapbook's root folder (the
-folder that contains the "pages" folder). By default, only one scrapbook is configured and
-it's name is "scrapbook" which means that both "/scrapbook" and "/scrapbook/scrapbook" point
-to the same scrapbook root page.
+To view a scrapbook, navigate to its base URL setup by the route file configuration. (See
+the documentation for the `scrapbook` route helper for more information on how to conigure
+this route.)
 
 ## Configuration
 
-You can configure the path that Scrapbook runs on in your "config/routes.rb" file. The
-default configuration is to mount Scrapbook on "/scrapbook", but you can use whatever
-path you want: `mount Scrapbook::Engine => "/scrappy"`.
+The installation task adds `extend Scrapbook::Routing` to the routes configuration block
+which gives it access to the `scrapbook` route helper. It also addds a scrapbook named
+"scrapbook" using that helper (`scrapbook('scrapbook')`). You can modify that configuration,
+specifying the location of the folder root or the URL path to mount the scrapbook at. You
+can also add additional scrapbooks using this helper. For example:
 
-You can configure one or more folders to be separate root scrapbooks via the
-`config.scrapbook.paths` option. This option defaults to an empty array which allows for
-using the shovel operator to add your paths:
 ```ruby
-Rails.application.configure do
-  config.scrapbook.paths << Rails.root.join("scrapbooks/main")
-  config.scrapbook.paths << Rails.root.join("scrapbooks/scratch")
+Rails.application.routes.draw do
+  extend Scrapbook::Routing
+
+  scrapbook('main', at: '/scrapbook', folder_root: 'scrapbooks/main')
+  scrapbook('scratch', folder_root: 'scrapbooks/scratch')
 end
 ```
-If no paths have been added, Scrapbook will use `Rails.root.join('scrapbook')` as the
-location it expects the scrapbook to be at. The first folder path in the array is considered
-the default scrapbook and will be available at the root mount point configured in the routes
-file.
 
 We recommend only running Scrapbook in development / non-production Rails environments.
 However, if you find yourself needing to be able to run it in an environment precompiles its

--- a/app/controllers/scrapbook/pages_controller.rb
+++ b/app/controllers/scrapbook/pages_controller.rb
@@ -51,12 +51,9 @@ module Scrapbook
     private
 
     def find_scrapbook
-      scrapbook_path = if params[:book].present?
-        ::Scrapbook::Engine.config.scrapbook.paths.find { File.basename(_1) == params[:book] }
-      else
-        ::Scrapbook::Engine.config.scrapbook.paths.first
-      end
+      return nil if book_name.blank?
 
+      scrapbook_path = Engine.config.scrapbook.paths[book_name]
       scrapbook_path && Scrapbook.new(scrapbook_path)
     end
 
@@ -73,6 +70,10 @@ module Scrapbook
       return false if Rails.version.to_i == 6 && template.include?('.')
 
       EmptyController.new.tap { |c| c.prepend_view_path(scrapbook.pages_pathname) }.template_exists?(template)
+    end
+
+    def book_name
+      params[:'.book']
     end
   end
 end

--- a/app/helpers/scrapbook/helper_for_view.rb
+++ b/app/helpers/scrapbook/helper_for_view.rb
@@ -10,12 +10,7 @@ module Scrapbook
 
     def short_path_to(pathname, scrapbook = nil)
       scrapbook ||= Scrapbook.find_scrapbook_for(pathname)
-
-      if scrapbook.root == ::Scrapbook::Engine.config.scrapbook.paths.first
-        view.short_page_path(scrapbook.relative_page_path_for(pathname))
-      else
-        view.book_page_path(scrapbook.relative_page_path_for(pathname), book: scrapbook.name)
-      end
+      view.short_page_path(scrapbook.relative_page_path_for(pathname))
     end
 
     def remove_handler_exts_from(pathname)

--- a/app/models/scrapbook/scrapbook.rb
+++ b/app/models/scrapbook/scrapbook.rb
@@ -9,11 +9,11 @@ module Scrapbook
 
     def self.find_scrapbook_for(pathname)
       scrapbooks = ::Scrapbook::Engine.config.scrapbook.paths
-      candidates = scrapbooks.each_with_index.filter_map do |pname, index|
+      candidates = scrapbooks.filter_map do |book, pname|
         relative_path = pathname.relative_path_from(pname)
         next if relative_path.to_s.start_with?('..')
 
-        [index, relative_path.each_filename.count]
+        [book, relative_path.each_filename.count]
       end
       raise NotFoundError if candidates.empty?
 
@@ -25,7 +25,7 @@ module Scrapbook
     end
 
     def name
-      root.basename
+      root.basename.to_s
     end
 
     def pages_pathname

--- a/app/views/scrapbook/pages/show.html.erb
+++ b/app/views/scrapbook/pages/show.html.erb
@@ -1,1 +1,1 @@
-<iframe src="<%= raw_page_path(book: scrapbook.name, id: scrapbook.relative_page_path_for(pathname)) %>" class="w-full h-full"></iframe>
+<iframe src="<%= raw_page_path(scrapbook.relative_page_path_for(pathname)) %>" class="w-full h-full"></iframe>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 Scrapbook::Engine.routes.draw do
-  book_regex = /#{Scrapbook::Engine.config.scrapbook.paths.map { File.basename(_1) }.join('|')}/
+  # TODO: Future plans
+  # scope path: '/.editor' do
+  #   resources :pages, id: /.+/, only: %i[new create edit update]
+  # end
 
-  resources :pages, id: /.+/
-  resources :pages, path: ':book/pages', id: /.+/, constraints: {book: book_regex}
-
-  get ':book', to: 'pages#index', constraints: {book: book_regex}
   root 'pages#index'
 
-  get '.raw/:book/pages/*id', to: 'pages#raw', as: :raw_page,
-    constraints: {book: book_regex, id: /.*/}, defaults: {raw: true}
-  get ':book/*id', to: 'pages#show', constraints: {book: book_regex, id: /.*/}, as: :book_page
+  get '.raw/pages/*id', to: 'pages#raw', constraints: {id: /.*/}, as: :raw_page
   get '*id', to: 'pages#show', constraints: {id: /.*/}, as: :short_page
 end

--- a/lib/generators/scrapbook/install_generator.rb
+++ b/lib/generators/scrapbook/install_generator.rb
@@ -5,11 +5,12 @@ require 'rails/generators'
 module Scrapbook
   # Initial default setup of Scrapbook
   class InstallGenerator < Rails::Generators::Base
-    class_option 'url-path', default: '/scrapbook'
     class_option 'path-with-name', default: 'scrapbook'
 
     def install
-      generate 'scrapbook:routes', options.fetch('url-path')
+      name = Pathname.new(options.fetch('path-with-name')).basename.to_s
+
+      generate 'scrapbook:routes', name
       generate 'scrapbook:new', options.fetch('path-with-name')
       sprockets_support
     end

--- a/lib/generators/scrapbook/routes_generator.rb
+++ b/lib/generators/scrapbook/routes_generator.rb
@@ -3,19 +3,21 @@
 require 'rails/generators'
 
 module Scrapbook
-  # A generator to create a new scrapbook at either the default (scrapbook) or specified
-  # path from the Rails application root.
+  # A generator to create a new scrapbook with  either the default (scrapbook) or specified
+  # name. (Using the default options for the URL path and folder root.)
   class RoutesGenerator < Rails::Generators::Base
-    argument :path, optional: true, default: '/scrapbook'
+    argument :name, optional: true, default: 'scrapbook'
 
     def routes
       # TODO: Investigate using a Rubocop rule to determine using single or double auotes.
-      url_path = path.start_with?('/') ? path : "/#{path}"
-      route <<~ROUTES
-        if Rails.env.development?
-          mount Scrapbook::Engine => '#{url_path}'
-        end
-      ROUTES
+
+      inject_into_file('config/routes.rb', after: "Rails.application.routes.draw do\n") do
+        "  extend Scrapbook::Routing\n"
+      end
+
+      inject_into_file('config/routes.rb', after: "extend Scrapbook::Routing\n") do
+        "\n  scrapbook('#{name}') if Rails.env.development?\n"
+      end
     end
   end
 end

--- a/lib/scrapbook.rb
+++ b/lib/scrapbook.rb
@@ -2,6 +2,7 @@
 
 require 'scrapbook/version'
 require 'scrapbook/engine'
+require 'scrapbook/routing'
 
 # TODO: Figure out documentation
 # Placeholder

--- a/lib/scrapbook/engine.rb
+++ b/lib/scrapbook/engine.rb
@@ -6,14 +6,8 @@ module Scrapbook
     isolate_namespace Scrapbook
 
     config.scrapbook = ActiveSupport::OrderedOptions.new
-    config.scrapbook.paths ||= []
+    config.scrapbook.paths ||= {}
     config.scrapbook.precompile_assets = config.scrapbook.precompile_assets || false
-
-    initializer 'scrapbook.configuration' do |app|
-      settings = app.config.scrapbook
-
-      settings.paths << Rails.root.join('scrapbook') if settings.paths.empty?
-    end
 
     initializer 'scrapbook.assets' do |app|
       if app.config.scrapbook.precompile_assets && app.config.respond_to?(:assets)

--- a/lib/scrapbook/routing.rb
+++ b/lib/scrapbook/routing.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Scrapbook
+  # This is a helper method for making it easier to add scrapbooks to routes.
+  module Routing
+    def scrapbook(name, at: "/#{name}", folder_root: name)
+      folder_root = Pathname.new(folder_root)
+      folder_root = Rails.root.join(folder_root) if folder_root.relative?
+
+      Engine.config.scrapbook.paths[name] = folder_root
+      mount Engine => at, defaults: {'.book': name}, as: "#{name}_scrapbook"
+    end
+  end
+end

--- a/spec/controllers/scrapbook/pages_controller_spec.rb
+++ b/spec/controllers/scrapbook/pages_controller_spec.rb
@@ -8,238 +8,127 @@ RSpec.describe Scrapbook::PagesController, :aggregate_failures do
   describe '#index' do
     let(:scrapbook) { Scrapbook::Scrapbook.new(PathnameHelpers.new.scrapbook_root) }
 
-    context 'when no book is specified' do
-      it 'gets the listing of the pages directory for the default scrapbook' do
-        get :index
-        pathname = scrapbook.pages_pathname
+    it 'gets the listing of the pages directory for the specified book' do
+      get :index, params: {'.book': 'scrapbook'}
+      pathname = scrapbook.pages_pathname
 
-        expect(pathname).not_to be_empty
-        expect(response).to have_http_status(:ok).and render_template('pages')
-        expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
-      end
-
-      it 'gets the listing of the specified sub directory for the default scrapbook' do
-        get :index, params: {path: 'components'}
-        pathname = scrapbook.pages_pathname.join('components')
-
-        expect(pathname).not_to be_empty
-        expect(response).to have_http_status(:ok).and render_template(:index)
-        expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
-      end
-
-      it 'renders the root template for the root directory if it exists' do
-        FileUtils.touch(scrapbook.pages_pathname.sub_ext('.html.erb'))
-
-        get :index
-        expect(response).to have_http_status(:ok).and render_template('pages')
-        expect(template_locals).to include(scrapbook: scrapbook, pathname: scrapbook.pages_pathname)
-      ensure
-        FileUtils.remove_file(scrapbook.pages_pathname.sub_ext('.html.erb'))
-      end
-
-      it "returns a 404 error when the path doesn't exist" do
-        get :index, params: {path: 'missing'}
-        expect(response).to have_http_status(:not_found)
-      end
+      expect(pathname).not_to be_empty
+      expect(response).to have_http_status(:ok).and render_template('pages')
+      expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
     end
 
-    context 'with a specified book' do
-      it 'gets the listing of the pages directory for the specified book' do
-        get :index, params: {book: 'scrapbook'}
-        pathname = scrapbook.pages_pathname
+    it 'gets the listing of the specified sub directory for the specified book' do
+      get :index, params: {'.book': 'scrapbook', path: 'components'}
+      pathname = scrapbook.pages_pathname.join('components')
 
-        expect(pathname).not_to be_empty
-        expect(response).to have_http_status(:ok).and render_template('pages')
-        expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
-      end
+      expect(pathname).not_to be_empty
+      expect(response).to have_http_status(:ok).and render_template(:index)
+      expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
+    end
 
-      it "returns a 404 error when the book doesn't exist" do
-        get :index, params: {book: 'missing'}
-        expect(response).to have_http_status(:not_found)
-      end
+    it "returns a 404 error when the book doesn't exist" do
+      get :index, params: {'.book': 'missing'}
+      expect(response).to have_http_status(:not_found)
+    end
 
-      it 'gets the listing of the specified sub directory for the specified book' do
-        get :index, params: {book: 'scrapbook', path: 'components'}
-        pathname = scrapbook.pages_pathname.join('components')
+    it "returns a 404 error when the path doesn't exist" do
+      get :index, params: {'.book': 'scrapbook', path: 'missing'}
+      expect(response).to have_http_status(:not_found)
+    end
 
-        expect(pathname).not_to be_empty
-        expect(response).to have_http_status(:ok).and render_template(:index)
-        expect(template_locals).to include(scrapbook: scrapbook, pathname: pathname)
-      end
-
+    context 'when no book is specified' do
       it "returns a 404 error when the path doesn't exist" do
-        get :index, params: {path: 'missing'}
+        get :index, params: {path: 'my/cool/path'}
         expect(response).to have_http_status(:not_found)
       end
     end
   end
 
   describe '#show' do
-    context 'when short path or pages path is used' do
-      it 'renders the show template when the specified template exists in the default scrapbook' do
-        get :show, params: {id: 'welcome'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
-
-      it 'renders the show template when a template exists in the default scrapbook that matches a request with an "html" extension' do # rubocop:disable Layout/LineLength
-        get :show, params: {id: 'welcome.html'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
-
-      it 'renders a directory listing for the specified folder in the default scrapbook' do
-        get :show, params: {id: 'components/folder_name/sub_stuff'}
-        expect(response).to render_template('index')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
-
-      it 'renders the show template when a non-template file is requested' do
-        get :show, params: {id: 'assets/fireworks.jpg'}
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
-
-      it 'prefers to render the show template over a directory or file' do
-        get :show, params: {id: 'show'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
-
-      it "renders the show template when the path doesn't exist" do
-        get :show, params: {id: 'missing'}
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it 'renders the show template when the specified template exists in the specified scrapbook' do
+      get :show, params: {'.book': 'scrapbook', id: 'welcome'}
+      expect(response).to render_template('show')
+      expect(response).to render_template('layouts/scrapbook/application')
     end
 
-    context 'with book in the path' do
-      it 'renders the show template when the specified template exists in the specified scrapbook' do
-        get :show, params: {book: 'scrapbook', id: 'welcome'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it 'renders the show template when a template exists in the specified scrapbook that matches a request with an "html" extension' do # rubocop:disable Layout/LineLength
+      get :show, params: {'.book': 'scrapbook', id: 'welcome.html'}
+      expect(response).to render_template('show')
+      expect(response).to render_template('layouts/scrapbook/application')
+    end
 
-      it 'renders the show template when a template exists in the specified scrapbook that matches a request with an "html" extension' do # rubocop:disable Layout/LineLength
-        get :show, params: {book: 'scrapbook', id: 'welcome.html'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it 'renders a directory listing for the specified folder in the specified scrapbook' do
+      get :show, params: {'.book': 'scrapbook', id: 'components/folder_name/sub_stuff'}
+      expect(response).to render_template('scrapbook/pages/index')
+      expect(response).to render_template('layouts/scrapbook/application')
+    end
 
-      it 'renders a directory listing for the specified folder in the specified scrapbook' do
-        get :show, params: {book: 'scrapbook', id: 'components/folder_name/sub_stuff'}
-        expect(response).to render_template('scrapbook/pages/index')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it 'renders the show template when a non-template file is requested' do
+      get :show, params: {'.book': 'scrapbook', id: 'assets/fireworks.jpg'}
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('show')
+      expect(response).to render_template('layouts/scrapbook/application')
+    end
 
-      it 'renders the show template when a non-template file is requested' do
-        get :show, params: {book: 'scrapbook', id: 'assets/fireworks.jpg'}
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it 'prefers to render the show template over a directory or file' do
+      get :show, params: {'.book': 'scrapbook', id: 'components/folder_name'}
+      expect(response).to render_template('show')
+      expect(response).to render_template('layouts/scrapbook/application')
+    end
 
-      it 'prefers to render the show template over a directory or file' do
-        get :show, params: {book: 'scrapbook', id: 'components/folder_name'}
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it "renders the show template when the path doesn't exist" do
+      get :show, params: {'.book': 'scrapbook', id: 'missing'}
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template('show')
+      expect(response).to render_template('layouts/scrapbook/application')
+    end
 
-      it "renders the show template when the path doesn't exist" do
-        get :show, params: {book: 'scrapbook', id: 'missing'}
-        expect(response).to have_http_status(:ok)
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-      end
+    it "returns a 404 error when the scrapbook doesn't exist" do
+      get :show, params: {'.book': 'missing', id: 'welcome'}
+      expect(response).to have_http_status(:not_found)
+    end
 
-      it "returns a 404 error when the scrapbook doesn't exist" do
-        get :show, params: {book: 'missing', id: 'welcome'}
+    context 'when no book is specified' do
+      it "returns a 404 error when the path doesn't exist" do
+        get :show, params: {id: 'my/cool/path'}
         expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context 'when viewing the ID "pages"' do
-      render_views # Can't be called or configured in an example
-
-      let(:scrapbook) { Scrapbook::Scrapbook.new(PathnameHelpers.new.scrapbook_root) }
-
-      it 'renders the raw path, even when it does not exist, when given a short or pages path' do
-        get :show, params: {id: 'pages'}
-
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-        expect(response.body).to match(controller.raw_page_path(book: scrapbook.name, id: 'pages'))
-      end
-
-      it 'renders the raw path, even if it does not exist, when given a book path' do
-        get :show, params: {book: 'scrapbook', id: 'pages'}
-
-        expect(response).to render_template('show')
-        expect(response).to render_template('layouts/scrapbook/application')
-        expect(response.body).to match(controller.raw_page_path(book: scrapbook.name, id: 'pages'))
       end
     end
   end
 
   describe '#raw' do
     it 'renders the specified template for the specified scrapbook' do
-      get :raw, params: {book: 'scrapbook', id: 'welcome'}
+      get :raw, params: {'.book': 'scrapbook', id: 'welcome'}
       expect(response).to render_template('welcome')
       expect(response).to render_template('layouts/scrapbook/host_application')
     end
 
     it 'renders the matching template for a request with an "html" extension in the specified scrapbook' do
-      get :raw, params: {book: 'scrapbook', id: 'welcome.html'}
+      get :raw, params: {'.book': 'scrapbook', id: 'welcome.html'}
       expect(response).to render_template('welcome')
       expect(response).to render_template('layouts/scrapbook/host_application')
     end
 
     it 'renders the file directly if it is not a template' do
-      get :raw, params: {book: 'scrapbook', id: 'assets/fireworks.jpg'}
+      get :raw, params: {'.book': 'scrapbook', id: 'assets/fireworks.jpg'}
       expect(response).to have_http_status(:ok)
       expect(response).to render_template(nil)
     end
 
     it 'prefers to render the template over a directory or file' do
-      get :raw, params: {book: 'scrapbook', id: 'components/folder_name'}
+      get :raw, params: {'.book': 'scrapbook', id: 'components/folder_name'}
       expect(response).to render_template('components/folder_name')
       expect(response).to render_template('layouts/scrapbook/host_application')
     end
 
     it "returns a 404 error when the path doesn't exist" do
-      get :raw, params: {book: 'scrapbook', id: 'missing'}
+      get :raw, params: {'.book': 'scrapbook', id: 'missing'}
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns a 404 error when the scrapbook doesn't exist" do
-      # The route constraint means the 404 will be hit in Rails, not in our controller
-      expect {
-        get :raw, params: {book: 'missing', id: 'welcome'}
-      }.to raise_error(ActionController::UrlGenerationError)
-    end
-
-    context 'when viewing the ID "pages"' do
-      render_views # Can't be called or configured in an example
-
-      let(:scrapbook) { Scrapbook::Scrapbook.new(PathnameHelpers.new.scrapbook_root) }
-
-      it 'renders the page if it exists' do
-        scrapbook.pages_pathname.join('pages.html.erb').write('edge-case for /pages')
-        get :raw, params: {book: 'scrapbook', id: 'pages'}
-
-        expect(response).to render_template('pages')
-        expect(response).to render_template('layouts/scrapbook/host_application')
-        expect(response.body).to match(%r`edge-case for /pages`)
-      ensure
-        FileUtils.remove_file(scrapbook.pages_pathname.join('pages.html.erb'))
-      end
-
-      it %(renders not found if it doesn't exist) do
-        get :raw, params: {book: 'scrapbook', id: 'pages'}
-        expect(response).to have_http_status(:not_found)
-      end
+      get :raw, params: {'.book': 'missing', id: 'welcome'}
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/generators/scrapbook/install_generator_spec.rb
+++ b/spec/generators/scrapbook/install_generator_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Scrapbook::InstallGenerator do
       end
 
       it "adds the configuration for scrapbook's CSS file" do
-        generator.send(:sprockets_support)
+        capture(:stdout) { generator.send(:sprockets_support) }
         expect(relative_pathname('app/assets/config/manifest.js').read)
           .to match(%r`^//= link scrapbook/application.css$`)
       end
@@ -28,7 +28,7 @@ RSpec.describe Scrapbook::InstallGenerator do
 
     context 'without a sprockets manifest file' do
       it 'skips sprockets support' do
-        generator.send(:sprockets_support)
+        capture(:stdout) { generator.send(:sprockets_support) }
         expect(relative_pathname('app/assets/config/manifest.js')).not_to exist
       end
     end

--- a/spec/helpers/scrapbook/helper_for_view_spec.rb
+++ b/spec/helpers/scrapbook/helper_for_view_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require 'support/shared_contexts/scrapcook'
 
 RSpec.describe Scrapbook::HelperForView do
   describe '#short_path_to' do
@@ -52,30 +51,6 @@ RSpec.describe Scrapbook::HelperForView do
       let(:scrapbook) { Scrapbook::Scrapbook.new(PathnameHelpers.new.scrapbook_root) }
 
       it { will_be_expected.to raise_error(ArgumentError) }
-    end
-
-    context 'when linking to folders in a scrapbook that is not the default one' do
-      include_context 'configure scrapcook'
-
-      let(:scrapbook_root) { PathnameHelpers.new.scrapbook_root('scrapcook') }
-      let(:pathname) { PathnameHelpers.new.pages_pathname(scrapbook_root).join(relative_path) }
-      let(:relative_path) { 'pastry' }
-
-      it 'returns a linkable path prefixed with the scrapbook' do
-        expect(path).to eql(helper.book_page_path(relative_path, book: 'scrapcook'))
-      end
-    end
-
-    context 'when linking to files in a scrapbook that is not the default one' do
-      include_context 'configure scrapcook'
-
-      let(:scrapbook_root) { PathnameHelpers.new.scrapbook_root('scrapcook') }
-      let(:pathname) { PathnameHelpers.new.pages_pathname(scrapbook_root).join(relative_path) }
-      let(:relative_path) { 'pastry/croissant.html.erb' }
-
-      it 'returns a linkable path prefixed with the scrapbook' do
-        expect(path).to eql(helper.book_page_path(relative_path, book: 'scrapcook'))
-      end
     end
   end
 

--- a/spec/lib/scrapbook/engine_spec.rb
+++ b/spec/lib/scrapbook/engine_spec.rb
@@ -3,37 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe Scrapbook::Engine do
-  describe 'configuring the engine' do
-    it 'defaults to scrapbook' do
-      skip 'USE_CUSTOM_PATH is set' if ENV['USE_CUSTOM_PATH'].present?
-
-      expect(described_class.config.scrapbook.paths)
-        .to eql([Rails.root.join('scrapbook')])
-    end
-
-    it 'allows the application to configure scrapbook paths' do
-      skip 'USE_CUSTOM_PATH not set' if ENV['USE_CUSTOM_PATH'].blank?
-
-      expect(described_class.config.scrapbook.paths)
-        .to eql([Rails.root.join('custom/scrapbook/path')])
-    end
-  end
+  # describe 'configuring the engine' do
+  #   it 'defaults to an empty hash scrapbook' do
+  #     expect(described_class.config.scrapbook.paths).to eql({})
+  #   end
+  # end
 
   describe 'configuring asset precompilation' do
     it 'defaults to not precompiling assets' do
-      skip 'PRECOMPILE_ASSETS is set' if ENV['PRECOMPILE_ASSETS'].present?
-
       expect(described_class.config.scrapbook.precompile_assets).to be false
       expect(described_class.config.assets.precompile)
         .to exclude('scrapbook/application.css')
-    end
-
-    it 'allows the application to turn on asset precompilation' do
-      skip 'PRECOMPILE_ASSETS not set' if ENV['PRECOMPILE_ASSETS'].blank?
-
-      expect(described_class.config.scrapbook.precompile_assets).to be true
-      expect(described_class.config.assets.precompile)
-        .to include('scrapbook/application.css')
     end
   end
 end

--- a/spec/lib/scrapbook/routing_spec.rb
+++ b/spec/lib/scrapbook/routing_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Scrapbook::Routing do
+  # rubocop:disable RSpec/SubjectStub
+  describe '#scrapbook' do
+    subject(:object) { double('router').extend(described_class) } # rubocop:disable RSpec/VerifiedDoubles
+
+    let(:books) { {} }
+
+    before do
+      allow(::Scrapbook::Engine.config.scrapbook).to receive(:paths)
+        .and_return(books)
+      allow(object).to receive(:mount)
+    end
+
+    it 'creates a scrapbook entry in the configuration with the default file location' do
+      object.scrapbook('book')
+
+      expect(books).to include('book' => Rails.root.join('book'))
+    end
+
+    it 'mounts Scrapbook with the default values' do
+      object.scrapbook('book')
+
+      expect(object).to have_received(:mount).with(hash_including(
+        ::Scrapbook::Engine => '/book',
+        defaults: {'.book': 'book'},
+        as: 'book_scrapbook'
+      ))
+    end
+
+    context 'when passed a URL path' do
+      it 'mounts Scrapbook at the specified path' do
+        path = '/my/path'
+        object.scrapbook('book', at: path)
+
+        expect(object).to have_received(:mount).with(hash_including(
+          ::Scrapbook::Engine => path,
+          defaults: {'.book': 'book'},
+          as: 'book_scrapbook'
+        ))
+      end
+    end
+
+    context 'when passed a folder root' do
+      it 'configures the scrapbook entry with the specified root folder' do
+        root = '/the/path/to/book/root'
+        object.scrapbook('book', folder_root: root)
+
+        expect(books).to include('book' => Pathname.new(root))
+      end
+
+      it 'configures the scrapbook entry with the specified root folder relative to Rails.root' do
+        path = 'relative/path/to/root'
+        object.scrapbook('book', folder_root: path)
+
+        expect(books).to include('book' => Rails.root.join(path))
+      end
+    end
+  end
+  # rubocop:enable RSpec/SubjectStub
+end

--- a/spec/models/scrapbook/scrapbook_spec.rb
+++ b/spec/models/scrapbook/scrapbook_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Scrapbook::Scrapbook do
 
       before do
         allow(::Scrapbook::Engine.config.scrapbook).to receive(:paths)
-          .and_return([base_pathname, nested_pathname])
+          .and_return({'book1' => base_pathname, 'nested' => nested_pathname})
       end
 
       it { is_expected.to eql(described_class.new(nested_pathname)) }
@@ -36,7 +36,7 @@ RSpec.describe Scrapbook::Scrapbook do
   describe '#name' do
     subject { scrapbook.name }
 
-    it { is_expected.to eql(scrapbook.root.basename) }
+    it { is_expected.to eql(scrapbook.root.basename.to_s) }
   end
 
   describe '#pages_pathname' do

--- a/spec/routing/scrapbook_routes_spec.rb
+++ b/spec/routing/scrapbook_routes_spec.rb
@@ -5,201 +5,36 @@ require 'rails_helper'
 RSpec.describe Scrapbook do
   routes { Scrapbook::Engine.routes }
 
-  describe 'Routes to root / Pages#index' do
-    context 'with the short route to route' do
-      subject { {get: '/'} }
+  describe 'the root route (/)' do
+    subject { {get: '/'} }
 
-      it { is_expected.to route_to(controller: 'scrapbook/pages', action: 'index') }
-    end
-
-    context 'with the pages prefix' do
-      subject { {get: '/pages'} }
-
-      it { is_expected.to route_to(controller: 'scrapbook/pages', action: 'index') }
-    end
-
-    context 'with the book prefix' do
-      subject { {get: '/scrapbook'} }
-
-      it { is_expected.to route_to(controller: 'scrapbook/pages', action: 'index', book: 'scrapbook') }
-    end
-
-    context 'with both the book and pages prefix' do
-      subject { {get: '/scrapbook/pages'} }
-
-      it { is_expected.to route_to(controller: 'scrapbook/pages', action: 'index', book: 'scrapbook') }
-    end
+    it { is_expected.to route_to(controller: 'scrapbook/pages', action: 'index') }
   end
 
   describe 'Direct routes to pages' do
-    context 'without the pages prefix' do
-      it 'correctly routes viewing a long path' do
-        expect(get: '/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes viewing a long file' do
-        expect(get: '/area/subject/item.xml').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          id: 'area/subject/item.xml'
-        )
-      end
+    it 'correctly routes viewing a long path' do
+      expect(get: '/area/subject/item').to route_to(
+        controller: 'scrapbook/pages',
+        action: 'show',
+        id: 'area/subject/item'
+      )
     end
 
-    context 'with the pages prefix' do
-      it 'correctly routes indexing the pages' do
-        expect(get: '/pages').to route_to('scrapbook/pages#index')
-      end
-
-      it 'correctly routes viewing a long path' do
-        expect(get: '/pages/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes viewing a long file' do
-        expect(get: '/pages/area/subject/item.xml').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          id: 'area/subject/item.xml'
-        )
-      end
-
-      it 'correctly routes viewing a page named pages' do
-        expect(get: '/pages/pages').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          id: 'pages'
-        )
-      end
-
-      it 'correctly routes editing a long path' do
-        expect(get: '/pages/area/subject/item/edit').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'edit',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes updating a long path' do
-        expect(put: '/pages/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'update',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes the new page path' do
-        expect(get: '/pages/new').to route_to('scrapbook/pages#new')
-      end
-
-      it 'correctly routes creating a new page' do
-        expect(post: '/pages').to route_to('scrapbook/pages#create')
-      end
-    end
-  end
-
-  # Since the default book is "scrapbook", that's the prefix we will use. This
-  # means that mounted under "scrapbook" in an application, the URLs would be
-  # in the form "/scrapbook/scrapbook/..."
-  describe 'Book-prefixed routes to pages' do
-    context 'without the pages prefix' do
-      it 'correctly routes viewing a long path' do
-        expect(get: '/scrapbook/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          book: 'scrapbook',
-          id: 'area/subject/item'
-        )
-      end
-    end
-
-    context 'with the pages prefix' do
-      it 'correctly routes indexing the pages' do
-        expect(get: '/scrapbook/pages').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'index',
-          book: 'scrapbook'
-        )
-      end
-
-      it 'correctly routes viewing a long path' do
-        expect(get: '/scrapbook/pages/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          book: 'scrapbook',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes viewing a long file' do
-        expect(get: '/scrapbook/pages/area/subject/item.xml').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          book: 'scrapbook',
-          id: 'area/subject/item.xml'
-        )
-      end
-
-      it 'correctly routes viewing a page named pages' do
-        expect(get: '/scrapbook/pages/pages').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'show',
-          book: 'scrapbook',
-          id: 'pages'
-        )
-      end
-
-      it 'correctly routes editing a long path' do
-        expect(get: '/scrapbook/pages/area/subject/item/edit').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'edit',
-          book: 'scrapbook',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes updating a long path' do
-        expect(put: '/scrapbook/pages/area/subject/item').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'update',
-          book: 'scrapbook',
-          id: 'area/subject/item'
-        )
-      end
-
-      it 'correctly routes the new page path' do
-        expect(get: '/scrapbook/pages/new').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'new',
-          book: 'scrapbook'
-        )
-      end
-
-      it 'correctly routes creating a new page' do
-        expect(post: '/scrapbook/pages').to route_to(
-          controller: 'scrapbook/pages',
-          action: 'create',
-          book: 'scrapbook'
-        )
-      end
+    it 'correctly routes viewing a long file' do
+      expect(get: '/area/subject/item.xml').to route_to(
+        controller: 'scrapbook/pages',
+        action: 'show',
+        id: 'area/subject/item.xml'
+      )
     end
   end
 
   describe 'Raw routes to pages' do
     it 'correctly routes to the show page path' do
-      expect(get: '/.raw/scrapbook/pages/area/subject/item.xml').to route_to(
+      expect(get: '/.raw/pages/area/subject/item.xml').to route_to(
         controller: 'scrapbook/pages',
         action: 'raw',
-        book: 'scrapbook',
-        id: 'area/subject/item.xml',
-        raw: true
+        id: 'area/subject/item.xml'
       )
     end
   end

--- a/spec/support/shared_contexts/scrapcook.rb
+++ b/spec/support/shared_contexts/scrapcook.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_context 'configure scrapcook' do # rubocop:disable RSpec/ContextWording
-  before do
-    allow(::Scrapbook::Engine.config.scrapbook).to receive(:paths)
-      .and_return(Rails.application.config.scrapbook.paths + [Rails.root.join('scrapcook')])
-    Rails.application.reload_routes!
-  end
-end

--- a/test/boxcar/config/application.rb
+++ b/test/boxcar/config/application.rb
@@ -35,13 +35,5 @@ module Boxcar
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-
-    if ENV['USE_CUSTOM_PATH'].present?
-      config.scrapbook.paths << Rails.root.join('custom/scrapbook/path')
-    end
-
-    if ENV['PRECOMPILE_ASSETS'].present?
-      config.scrapbook.precompile_assets = true
-    end
   end
 end

--- a/test/boxcar/config/routes.rb
+++ b/test/boxcar/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Scrapbook::Engine => '/scrapbook'
+  extend Scrapbook::Routing
+
+  scrapbook('scrapbook')
 end


### PR DESCRIPTION
Instead of having one path that all the scrapbooks route through, this allows each scrapbook to be mounted on their own path. It involves completely re-architecting how Scrapbook is setup and configured. Dig into the new README for details.