### PR TITLE
Create template helper for Scrapbook pages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,9 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Max: 20
 
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
 RSpec:
   Language:
     Expectations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
 
 ## Unreleased
 
+### Added
+
+- Added a Rails helper method named `sb` that returns an object that will be used to create
+  helper methods that can be used inside Scrapbook pages. For example, if you wanted access
+  to the Scrapbook object inside a Scrapbook page template, you could call `sb.scrapbook`.
+
 ### Changed
 
 - Renamed internal class `HelperForView` to `HelperForNavView` as it contains helpers for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
 - Renamed internal class `HelperForView` to `HelperForNavView` as it contains helpers for
   the navigation tree.
 
+### Deprecated
+
+- If you are using either `scrapbook` or `pathname` in your Scrapbook pages, they are now
+  deprecated and will be removed in a future release. Instead, use the new `sb` helper
+  method: `sb.scrapbook` and `sb.pathname`.
+
 [Unreleased commits](https://github.com/bfad/scrapbook/compare/v0.3.2...HEAD)
 
 ## 0.3.2

--- a/app/controllers/scrapbook/pages_controller.rb
+++ b/app/controllers/scrapbook/pages_controller.rb
@@ -33,10 +33,12 @@ module Scrapbook
       if scrapbook_template_exists?(scrapbook, template)
         prepend_view_path(scrapbook.root)
         render template: template,
+          # DEPRECATED: The locals "scrapbook" and "pathname". Use `sb.scrapbook` and `sb.pathname` instead.
           locals: {scrapbook: scrapbook, pathname: pathname},
           layout: 'layouts/scrapbook/host_application'
       elsif pathname.directory?
         render '/pages',
+          # DEPRECATED: The locals "scrapbook" and "pathname". Use `sb.scrapbook` and `sb.pathname` instead.
           locals: {scrapbook: scrapbook, pathname: pathname},
           layout: 'layouts/scrapbook/host_application'
       elsif pathname.exist?

--- a/app/helpers/scrapbook/helper_for_template_view.rb
+++ b/app/helpers/scrapbook/helper_for_template_view.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Scrapbook
+  # Implementation of methods that can be used in views by accessing the `sb` helper method.
+  class HelperForTemplateView
+    attr_reader :scrapbook, :pathname
+
+    def initialize(view, scrapbook, pathname)
+      self.view = view
+      self.scrapbook = scrapbook
+      self.pathname = pathname
+    end
+
+    private
+
+    attr_accessor :view
+    attr_writer :scrapbook, :pathname
+  end
+end

--- a/app/helpers/scrapbook/pages_helper.rb
+++ b/app/helpers/scrapbook/pages_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Scrapbook
+  # View helpers for use in Scrapbook pages. All the methods are defined in the
+  # `HelperForTemplateView` class while here we only define one method to namespace all of
+  # them. This helps to avoid any conflicts with the host app.
+  module PagesHelper
+    def sb
+      @_sb ||= HelperForTemplateView.new(self, controller.send(:scrapbook), controller.send(:pathname))
+    end
+  end
+end

--- a/app/views/pages.html.erb
+++ b/app/views/pages.html.erb
@@ -1,2 +1,2 @@
-<% if pathname == scrapbook.pages_pathname %>This directory has no corresponding template. You can add a template named "pages" to the Scrapbook root directory and its contents will show up here.
+<% if sb.pathname == sb.scrapbook.pages_pathname %>This directory has no corresponding template. You can add a template named "pages" to the Scrapbook root directory and its contents will show up here.
 <% else %>This directory has no corresponding template. You can add a template with the same name as the directory as a sibling to the directory and its contents will show up here.<% end %>

--- a/spec/helpers/scrapbook/pages_helper_spec.rb
+++ b/spec/helpers/scrapbook/pages_helper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Scrapbook::PagesHelper do
+  describe '#sb' do
+    context 'when the controller does not define the scrapbook or pathname methods' do
+      it 'raises an error about a missing method' do
+        expect { helper.sb }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'when the controller defines both `#scrapbook` and `#pathname` methods' do
+      before do
+        helper.controller.define_singleton_method(:scrapbook) do
+          Scrapbook::Scrapbook.new(Pathname.new('/tmp'))
+        end
+
+        helper.controller.define_singleton_method(:pathname) do
+          Pathname.new('/tmp')
+        end
+      end
+
+      it 'returns an instance of `HelperForTemplateView`' do
+        expect(helper.sb).to be_a(Scrapbook::HelperForTemplateView)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates a helper method named `sb` that can be used by the Scrapbook gem to provide helper methods to be used by the Scrapbook pages of the host application. The idea is that all the helper methods the Scrapbook gem creates will actually be methods on the object that `sb` returns. This enables us to minimize potential name conflicts with the host-app's helper methods. For example, in the future I want to be able to create example could and display its source. I may make a method named "display_view_source" that users could use in their Scrapbook pages by calling `sb.display_view_source`, and this wouldn't conflict with their own definition of "display_view_source" that they could potentially have in their host application. 

Since I'm making this move, I'm also making `scrapbook` and `pathname` methods available to the object returned by `sb`. Right now every Scrapbook page is rendered with `scrapbook` and `pathname` as locals to those views, but in the future users will need to access them with `sb.scrapbook` and `sb.pathname`. Eventually, only the `sb` method could possibly conflict.