### PR TITLE
Add page helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,14 +16,10 @@ Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallBraceLayout:
-  EnforcedStyle: new_line
-
-Layout/MultilineMethodCallBraceLayout:
   Enabled: false
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
-  rubocop: warning
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
 - Added `sb.render_source` helper method that will output the source of a page wrapped in
   `<pre><code>` tags.
 
+- Added `sb.render_with_source` helper method which allows you to render the source of a
+  page (using `sb.render_source`) and then render the page itself within a `<div>` tag.
+
 ### Changed
 
 - Renamed internal class `HelperForView` to `HelperForNavView` as it contains helpers for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ may consider to be a bug might be behavior a consumer relies upon in their proje
   helper methods that can be used inside Scrapbook pages. For example, if you wanted access
   to the Scrapbook object inside a Scrapbook page template, you could call `sb.scrapbook`.
 
+- Added `sb.render_source` helper method that will output the source of a page wrapped in
+  `<pre><code>` tags.
+
 ### Changed
 
 - Renamed internal class `HelperForView` to `HelperForNavView` as it contains helpers for

--- a/app/helpers/scrapbook/helper_for_template_view.rb
+++ b/app/helpers/scrapbook/helper_for_template_view.rb
@@ -31,6 +31,26 @@ module Scrapbook
       tag.pre(tag.code(view.lookup_context.find(view_name, [], !partial.nil?).source))
     end
 
+    # Takes in a relative path to a scrapbook page and renders its source code followed by
+    # rendering the page itself. You specify the page as either a "template" or "partial"
+    # path similarly to how you would render a view in Rails, and you can pass in `locals`
+    # too.
+    #
+    # @param (see #render_source)
+    # @param locals [Hash] a key-value hash whose keys are the names of locals to assign
+    #   when the page is rendered.
+    # @return [String] the source code of a file wrapped in "<pre><code>" tags followed by
+    #   rendering the page itself wrapped in a "<div>".
+    def render_with_source(template: nil, partial: nil, locals: {})
+      # NOTE: Parameter validation of "template" and "partial" handled `render_source`.
+      source = render_source(template: template, partial: partial)
+      render_params = {locals: locals}
+      render_params[partial.nil? ? :template : :partial] =
+        pathname.relative_path_from(scrapbook.root).dirname.join(partial || template).to_s
+
+      source + tag.div(view.render(**render_params))
+    end
+
     private
 
     attr_accessor :view

--- a/app/helpers/scrapbook/helper_for_template_view.rb
+++ b/app/helpers/scrapbook/helper_for_template_view.rb
@@ -5,10 +5,30 @@ module Scrapbook
   class HelperForTemplateView
     attr_reader :scrapbook, :pathname
 
+    delegate :tag, to: :view
+
     def initialize(view, scrapbook, pathname)
       self.view = view
       self.scrapbook = scrapbook
       self.pathname = pathname
+    end
+
+    # Takes in a relative path to a scrapbook page and renders its source code. You specify
+    # the path as either a "template" or "partial" path similarly to how you would render a
+    # view in Rails. For example, `partial: "my/path/to/partial"` would look for a Scrapbook
+    # page named something like "my/path/to/_partial.html.erb" in the view paths.
+    #
+    # @param template [String] the relative path to a Scrapbook page similar to the path you
+    #   would give when rendering a Rails template. (Leave `nil` if specifying a partial.)
+    # @param partial [String] the relative path to a Scrapbook page similar to the path you
+    #   would give when rendering a Rails partial. (Leave `nil` if specifying a template.)
+    # @return [String] the source code of a file wrapped in "<pre><code>" tags.
+    def render_source(template: nil, partial: nil)
+      raise ArgumentError, 'Missing named parameter of either "partial" or "template"' if partial.nil? && template.nil?
+      raise ArgumentError, 'Can only pass one of either "partial" or "template"' if !partial.nil? && !template.nil?
+
+      view_name = pathname.relative_path_from(scrapbook.root).dirname.join(partial || template).to_s
+      tag.pre(tag.code(view.lookup_context.find(view_name, [], !partial.nil?).source))
     end
 
     private

--- a/spec/helpers/scrapbook/helper_for_template_view_spec.rb
+++ b/spec/helpers/scrapbook/helper_for_template_view_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Scrapbook::HelperForTemplateView do
+  subject(:sb) { described_class.new(helper, scrapbook, pathname) }
+
+  let(:scrapbook) { Scrapbook::Scrapbook.new(PathnameHelpers.new.scrapbook_root) }
+  let(:pathname) { PathnameHelpers.new.pages_pathname.join('components') }
+
+  before do
+    # The pages controller adds this when rendering Scrapbook pages
+    helper.controller.prepend_view_path(scrapbook.root)
+  end
+
+  describe '#render_source' do
+    it "renders a template's source code" do
+      source = File.read(PathnameHelpers.new.pages_pathname.join('components/austen.html.slim'))
+      expect(sb.render_source(template: 'components/austen'))
+        .to eql("<pre><code>#{source}</code></pre>")
+    end
+
+    it "renders a partial's source code" do
+      source = File.read(PathnameHelpers.new.pages_pathname.join('components/_partiality.html.slim'))
+      expect(sb.render_source(partial: 'components/partiality'))
+        .to eql("<pre><code>#{source}</code></pre>")
+    end
+
+    it 'fails if the passed partial does not exist' do
+      expect { sb.render_source(partial: 'components/austen') }
+        .to raise_error(ActionView::MissingTemplate)
+    end
+
+    it 'fails if the passed template does not exist' do
+      expect { sb.render_source(template: 'components/partiality') }
+        .to raise_error(ActionView::MissingTemplate)
+    end
+
+    it 'fails without passing either template or partial' do
+      expect { sb.render_source }.to raise_error(ArgumentError, /Missing named parameter/)
+    end
+
+    it 'fails if passed both template and partial' do
+      expect { sb.render_source(partial: '', template: '') }
+        .to raise_error(ArgumentError, /Can only pass one/)
+    end
+  end
+end

--- a/spec/helpers/scrapbook/helper_for_template_view_spec.rb
+++ b/spec/helpers/scrapbook/helper_for_template_view_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe Scrapbook::HelperForTemplateView do
     helper.controller.prepend_view_path(scrapbook.root)
   end
 
+  shared_examples 'requires "template" or "partial" named parameter and the file to exist' do
+    it 'fails without passing either template or partial' do
+      expect { sb.render_source }.to raise_error(ArgumentError, /Missing named parameter/)
+    end
+
+    it 'fails if passed both template and partial' do
+      expect { sb.render_source(partial: '', template: '') }
+        .to raise_error(ArgumentError, /Can only pass one/)
+    end
+
+    it 'fails if the passed partial does not exist' do
+      expect { sb.render_source(partial: 'components/austen') }
+        .to raise_error(ActionView::MissingTemplate)
+    end
+
+    it 'fails if the passed template does not exist' do
+      expect { sb.render_source(template: 'components/partiality') }
+        .to raise_error(ActionView::MissingTemplate)
+    end
+  end
+
   describe '#render_source' do
     it "renders a template's source code" do
       source = File.read(PathnameHelpers.new.pages_pathname.join('components/austen.html.slim'))
@@ -26,23 +47,39 @@ RSpec.describe Scrapbook::HelperForTemplateView do
         .to eql("<pre><code>#{source}</code></pre>")
     end
 
-    it 'fails if the passed partial does not exist' do
-      expect { sb.render_source(partial: 'components/austen') }
-        .to raise_error(ActionView::MissingTemplate)
+    it_behaves_like 'requires "template" or "partial" named parameter and the file to exist'
+  end
+
+  describe '#render_with_source' do
+    it "renders a template's source code followed by rendering the template itself" do
+      source = File.read(PathnameHelpers.new.pages_pathname.join('components/austen.html.slim'))
+      expect(sb.render_with_source(template: 'components/austen'))
+        .to eql(
+          "<pre><code>#{source}</code></pre><div><h1>Universal truth</h1>" \
+          '<p>Single person with a large fortune seeks a marriage partner.</p></div>'
+        )
     end
 
-    it 'fails if the passed template does not exist' do
-      expect { sb.render_source(template: 'components/partiality') }
-        .to raise_error(ActionView::MissingTemplate)
+    it "renders a partial's source code followed by rendering the partial itself" do
+      source = File.read(PathnameHelpers.new.pages_pathname.join('components/_partiality.html.slim'))
+      expect(sb.render_with_source(partial: 'components/partiality'))
+        .to eql("<pre><code>#{source}</code></pre><div><p>I am partial to pecan pie!</p></div>")
     end
 
-    it 'fails without passing either template or partial' do
-      expect { sb.render_source }.to raise_error(ArgumentError, /Missing named parameter/)
-    end
+    it_behaves_like 'requires "template" or "partial" named parameter and the file to exist'
 
-    it 'fails if passed both template and partial' do
-      expect { sb.render_source(partial: '', template: '') }
-        .to raise_error(ArgumentError, /Can only pass one/)
+    context 'when passed local variables' do
+      it 'passes the locals to the template' do
+        source = File.read(PathnameHelpers.new.pages_pathname.join('beta/locals.html.slim'))
+        expect(sb.render_with_source(template: 'beta/locals', locals: {name: 'World!'}))
+          .to eql("<pre><code>#{ERB::Util.html_escape_once(source)}</code></pre><div><p>Hello, World!</p></div>")
+      end
+
+      it 'passes the locals to the partial' do
+        source = File.read(PathnameHelpers.new.pages_pathname.join('beta/_locals.html.slim'))
+        expect(sb.render_with_source(partial: 'beta/locals', locals: {x: 'a', y: 'b'}))
+          .to eql("<pre><code>#{source}</code></pre><div><ul><li>a</li><li>b</li></ul></div>")
+      end
     end
   end
 end

--- a/test/boxcar/scrapbook/pages/beta/_locals.html.slim
+++ b/test/boxcar/scrapbook/pages/beta/_locals.html.slim
@@ -1,0 +1,3 @@
+ul
+  li = x
+  li = y

--- a/test/boxcar/scrapbook/pages/beta/locals.html.slim
+++ b/test/boxcar/scrapbook/pages/beta/locals.html.slim
@@ -1,0 +1,3 @@
+p
+  ' Hello,
+  = local_assigns[:name]

--- a/test/boxcar/scrapbook/pages/components/_partiality.html.slim
+++ b/test/boxcar/scrapbook/pages/components/_partiality.html.slim
@@ -1,0 +1,1 @@
+p I am partial to pecan pie!


### PR DESCRIPTION
Add helpers for rendering sample code. You can either just render the source itself, or you can render the source followed by actually rendering the page itself. (See individual commits and doc comments for details.)