### PR TITLE
bump-ruby-to-accomodate-7.2-patch

### DIFF
--- a/scrapbook.gemspec
+++ b/scrapbook.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.required_ruby_version = '>= 2.7.0'
-  spec.add_dependency 'rails', '>= 6.1', '< 7.2'
+  spec.add_dependency 'rails', '>= 6.1', '< 7.3'
 end


### PR DESCRIPTION
Hello @bfad - hope you are doing well. This is a simple PR that will provide compatibility for Ruby 7.2 and later patches. I have tested this installed in a private rails repo using scrapbook and have found no issues.